### PR TITLE
update to have year desc order

### DIFF
--- a/source/ngComboDatePicker.js
+++ b/source/ngComboDatePicker.js
@@ -21,7 +21,8 @@ angular.module("ngComboDatePicker", [])
             ngOrder: '@',
             ngAttrsDate: '@',
             ngAttrsMonth: '@',
-            ngAttrsYear: '@' 
+            ngAttrsYear: '@',
+						ngYearOrder: '@'
         },
         controller: ['$scope', function($scope) {
             // Define function for parse dates.
@@ -99,10 +100,17 @@ angular.module("ngComboDatePicker", [])
             if($scope.ngModel > $scope.maxDate) $scope.ngModel = $scope.maxDate;
 
             // Initialize list of years.
+						$scope.ngYearOrder = $scope.ngYearOrder ? $scope.ngYearOrder : "asc"; //set default order value
             $scope.years = [];
-            for(var i=$scope.minDate.getFullYear(); i<=$scope.maxDate.getFullYear(); i++) {
-                $scope.years.push(i);
-            }
+						if($scope.ngYearOrder == "desc") {
+							for(var i=$scope.maxDate.getFullYear(); i>=$scope.minDate.getFullYear(); i--) {
+									$scope.years.push(i);
+							}
+						} else {//"asc" order by default
+							for(var i=$scope.minDate.getFullYear(); i<=$scope.maxDate.getFullYear(); i++) {
+									$scope.years.push(i);
+							}
+						}
 
             // Initialize list of months names.
             var monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];


### PR DESCRIPTION
defaults at "asc" order but can use "desc" with an attribute like so:
ng-year-order="desc"

Note: needs the min.js created from whatever manual process you using to do that.
###### 

This is a nice add-on I think ... 
We have many old users for our pharma questionnaire so we start at 1910 but for most users its hard to scroll to the average year ... 
We also may have shared child and adult questionnaires, where 80% of people are filling out DOB for their child, but 20% of users may be filling out the DOB for themselves as adults ... 
so its easier to have 'newer' DOBs at the top for majority of users so dont have to scoll, 
and older DOBs closer to the bottom of dropdown for minority of people to scroll.

So this addition optionally allows year to go in desc order for those usability purposes mentioned above.
