### PR TITLE
Enable placeholders when model is cleared

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ngComboDatePicker",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "authors": [
     "jfmdev <jfmdev@inboxalias.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-combo-date-picker",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "An Angular directive to select dates using combo boxes",
   "main": "source/ngComboDatePicker.js",
   "scripts": {

--- a/source/ngComboDatePicker.js
+++ b/source/ngComboDatePicker.js
@@ -186,9 +186,19 @@ angular.module("ngComboDatePicker", [])
             // When the model is updated, update the combo boxes.
             $scope.modelUpdated = function() {
                 // Update combo boxes.
-                $scope.date = $scope.ngModel != null? $scope.ngModel.getDate() : '';
-                $scope.month = $scope.ngModel != null? $scope.ngModel.getMonth() : '';
-                $scope.year = $scope.ngModel != null? $scope.ngModel.getFullYear() : '';
+                if ($scope.ngModel) {
+                    $scope.date = $scope.ngModel.getDate();
+                    $scope.month = $scope.ngModel.getMonth();
+                    $scope.year = $scope.ngModel.getFullYear();
+                } else {
+                    $scope.date = '';
+                    $scope.month = '';
+                    $scope.year = '';
+                    
+                    placeHolders[0].disabled = false;
+                    placeHolders[1].disabled = false;
+                    placeHolders[2].disabled = false;
+                }
 
                 // Hide or show days and months according to the min and max dates.
                 $scope.updateMonthList();


### PR DESCRIPTION
Fixed the following things:
- Setting model to null doesn't trigger all components to be cleared when part of date components are set.
  For example, the ngModel is already set null, and user selects year and month, not date. In that case, there is no means to reset all date components(year, month, date) to blank state.
- Setting ngModel to null should enable placeholders back.
